### PR TITLE
problem: the kube-dash ui is not well known among the engineers who might benefit from it the most

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ### Changed:
 ### Fixed:
 
+[0.0.9] - 2017-03-09
+--------------------
+
+### Added:
+
+- New `kube-dash` micro-util added. Run it to open the kubernetes-dashboard
+- of the currently configured cluster in your browser. Uses `kubectl proxy`.
+
+### Changed:
+### Fixed:
+
 [0.0.8] - 2017-02-05
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ kubits
     + [kube-cluster](#kube-cluster)
     + [kube-ns](#kube-ns)
     + [kube-tail](#kube-tail)
+    + [kube-dash](#kube-dash)
   * [BASH / ZSH completion](#bash--zsh-completion)
 - [Developing](#developing)
+  * [Submitting changes](#submitting-changes)
+  * [Updating Homebrew Formula](#updating-homebrew-formula)
   * [TODO](#todo)
 
 <!-- tocstop -->
@@ -102,6 +105,18 @@ In this example, there is a single pod with two containers, nginx and myapp:
     $ kube-tail app=myapp production
     |myapp-11345623-gj2mr::nginx | 10.240.0.9 - - [18/Oct/2016:17:56:15 +0000] "GET /api/5bb0c1a8-0ad9-bcee-d3d3-f541bd3e7559/ HTTP/1.1" 200 3918 "-"
     |myapp-11345623-gj2mr::myapp | time="2016-10-18T17:36:29Z" level=info msg="New connection" clientIP=127.0.0.1:37768 conID=0dff04c5-4fa9-436c-8c08-f58d2b4e1e24
+
+### kube-dash
+
+Open the kubernetes-dashboard web UI of the currently configured cluster in your
+browser.
+
+A simple wrapper around `kubectl proxy` + `open http://localhost:8001/ui`.
+
+    $ kube-dash
+    <browser should open>
+    ctrl-C to exit
+
 
 BASH / ZSH completion
 ---------------------

--- a/kube-dash
+++ b/kube-dash
@@ -1,0 +1,9 @@
+#!/bin/sh
+# vim: set ft=sh:
+
+trap 'trap - INT TERM && kill -TERM -$$ >/dev/null 2>&1' INT TERM EXIT # ensure the script exits immediately on signal
+
+kubectl proxy >/dev/null &
+sleep 0.5
+open "http://localhost:8001/ui" &
+wait


### PR DESCRIPTION
solution: add a simple command - `kube-dash` - to smooth the path to
accessing kubernetes-dashboard web ui.

I love the cli but I was reminded from a talk at google next 2017 that
not all engineers are. We still want these engineers to be able to be
productive with kubernetes and hopefully this will help them discover
and use the web dashboard.