### PR TITLE
fix namespace reset in bash

### DIFF
--- a/completions/bash/_kube-ns.sh
+++ b/completions/bash/_kube-ns.sh
@@ -1,1 +1,1 @@
-complete -W "$(kube-ns kube-ns | awk '/Active/ {print $1}')" kube-ns
+complete -W "$(kube-ns | awk '/Active/ {print $1}')" kube-ns


### PR DESCRIPTION
Amended the bash completion to not pass `kube-ns` to `kube-ns`.