### PR TITLE
Add default pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v1.2.1
+    hooks:
+    -   id: check-yaml
+    -   id: trailing-whitespace
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+    -   id: check-json


### PR DESCRIPTION
As promised - here is an example of http://pre-commit.com/ config
to start using it do the following:
1. Install pre-commit `brew install pre-commit`.
1. Run `pre-commit install` in the repo folder - this will install hooks.

Then, when you commit any new changes it will run the hookes with the changed files.